### PR TITLE
Avisynth input module to use C API, support 10+ bits greyscale, allocate deterministic buffer size

### DIFF
--- a/source/input/avs.cpp
+++ b/source/input/avs.cpp
@@ -98,7 +98,7 @@ void AVSInput::load_avs()
     LOAD_AVS_FUNC(avs_release_value);
     LOAD_AVS_FUNC(avs_release_video_frame);
     LOAD_AVS_FUNC(avs_take_clip);
-    LOAD_AVS_FUNC(avs_is_y8);
+    LOAD_AVS_FUNC(avs_is_y);
     LOAD_AVS_FUNC(avs_is_420);
     LOAD_AVS_FUNC(avs_is_422);
     LOAD_AVS_FUNC(avs_is_444);
@@ -141,7 +141,7 @@ void AVSInput::openfile(InputFileInfo& info)
     info.frameCount = vi->num_frames;
     info.depth = h->func.avs_bits_per_component(vi);
     h->plane_count = 3;
-    if (h->func.avs_is_y8(vi))
+    if (h->func.avs_is_y(vi))
     {
         h->plane_count = 1;
         info.csp = X265_CSP_I400;

--- a/source/input/avs.cpp
+++ b/source/input/avs.cpp
@@ -1,7 +1,7 @@
 /*****************************************************************************
  * avs.c: avisynth input
  *****************************************************************************
- * Copyright (C) 2020 Xinyue Lu
+ * Copyright (C) 2020 Xinyue Lu, 2025 Avisynth developers
  *
  * Authors: Xinyue Lu <i@7086.in>
  *
@@ -31,6 +31,13 @@ if( cond )\
 }
 
 using namespace X265_NS;
+
+const int AVSInput::avs_planes_packed[1] = { 0 };
+const int AVSInput::avs_planes_grey[1] = { AVS_PLANAR_Y };
+const int AVSInput::avs_planes_yuv[3] = { AVS_PLANAR_Y, AVS_PLANAR_U, AVS_PLANAR_V };
+const int AVSInput::avs_planes_rgb[3] = { AVS_PLANAR_G, AVS_PLANAR_B, AVS_PLANAR_R };
+const int AVSInput::avs_planes_yuva[4] = { AVS_PLANAR_Y, AVS_PLANAR_U, AVS_PLANAR_V, AVS_PLANAR_A };
+const int AVSInput::avs_planes_rgba[4] = { AVS_PLANAR_G, AVS_PLANAR_B, AVS_PLANAR_R, AVS_PLANAR_A };
 
 lib_path_t AVSInput::convertLibraryPath(std::string path)
 {
@@ -98,11 +105,19 @@ void AVSInput::load_avs()
     LOAD_AVS_FUNC(avs_release_value);
     LOAD_AVS_FUNC(avs_release_video_frame);
     LOAD_AVS_FUNC(avs_take_clip);
+    LOAD_AVS_FUNC(avs_is_color_space);
+    LOAD_AVS_FUNC(avs_bit_blt);
     LOAD_AVS_FUNC(avs_is_y);
     LOAD_AVS_FUNC(avs_is_420);
     LOAD_AVS_FUNC(avs_is_422);
     LOAD_AVS_FUNC(avs_is_444);
+    LOAD_AVS_FUNC(avs_is_rgb48);
+    LOAD_AVS_FUNC(avs_is_rgb64);
     LOAD_AVS_FUNC(avs_bits_per_component);
+    LOAD_AVS_FUNC(avs_get_height_p);
+    LOAD_AVS_FUNC(avs_get_pitch_p);
+    LOAD_AVS_FUNC(avs_get_read_ptr_p);
+    LOAD_AVS_FUNC(avs_get_row_size_p);
     h->env = h->func.avs_create_script_environment(AVS_INTERFACE_26);
     return;
 fail:
@@ -133,35 +148,84 @@ void AVSInput::openfile(InputFileInfo& info)
     FAIL_IF_ERROR(avs_is_error(res), "Error loading file: %s\n", avs_as_string(res));
     FAIL_IF_ERROR(!avs_is_clip(res), "File didn't return a video clip\n");
     h->clip = h->func.avs_take_clip(res, h->env);
-    const AVS_VideoInfo* vi = h->func.avs_get_video_info(h->clip);
-    info.width = vi->width;
-    info.height = vi->height;
-    info.fpsNum = vi->fps_numerator;
-    info.fpsDenom = vi->fps_denominator;
-    info.frameCount = vi->num_frames;
-    info.depth = h->func.avs_bits_per_component(vi);
+    h->vi = h->func.avs_get_video_info(h->clip);
+    info.width = h->vi->width;
+    info.height = h->vi->height;
+    info.fpsNum = h->vi->fps_numerator;
+    info.fpsDenom = h->vi->fps_denominator;
+    info.frameCount = h->vi->num_frames;
+    info.depth = h->func.avs_bits_per_component(h->vi);
+
+    int planar = 1; // 0: packed, 1: YUV, 2: Y8, 3: Planar RGB, 4: YUVA, 5: Planar RGBA
+
     h->plane_count = 3;
-    if (h->func.avs_is_y(vi))
+    if (h->func.avs_is_y(h->vi))
     {
         h->plane_count = 1;
+        planar = 2;
         info.csp = X265_CSP_I400;
     }
-    else if (h->func.avs_is_420(vi))
+    else if (h->func.avs_is_420(h->vi))
     {
+        planar = 1;
         info.csp = X265_CSP_I420;
     }
-    else if (h->func.avs_is_422(vi))
+    else if (h->func.avs_is_422(h->vi))
     {
+        planar = 1;
         info.csp = X265_CSP_I422;
     }
-    else if (h->func.avs_is_444(vi))
+    else if (h->func.avs_is_444(h->vi))
     {
+        planar = 1;
         info.csp = X265_CSP_I444;
     }
+    /* RGB not supported at the moment by x265 */
+    /*
+    else if (avs_is_rgb24(h->vi) || h->func.avs_is_rgb48(h->vi))
+    {
+      planar = 0;
+      info.csp = X265_CSP_BGR;
+    }
+    else if (avs_is_rgb32(h->vi) || h->func.avs_is_rgb64(h->vi))
+    {
+      planar = 0;
+      info.csp = X265_CSP_BGRA;
+    }
+    */
     else
     {
         FAIL_IF_ERROR(1, "Video colorspace is not supported\n");
     }
+
+    // some of these are not supported, 
+    // still, keep their code for RFU
+    switch (planar) {
+    case 5: // Planar RGB + Alpha
+      h->plane_count = 4;
+      h->planes = avs_planes_rgba;
+      break;
+    case 4: // YUV + Alpha
+      h->plane_count = 4;
+      h->planes = avs_planes_yuva;
+      break;
+    case 3: // Planar RGB
+      h->plane_count = 3;
+      h->planes = avs_planes_rgb;
+      break;
+    case 2: // Y8
+      h->plane_count = 1;
+      h->planes = avs_planes_grey;
+      break;
+    case 1: // YUV
+      h->plane_count = 3;
+      h->planes = avs_planes_yuv;
+      break;
+    default:
+      h->plane_count = 1;
+      h->planes = avs_planes_packed;
+    }
+
 }
 
 void AVSInput::release()
@@ -188,27 +252,47 @@ bool AVSInput::readPicture(x265_picture& pic)
     pic.height = _info.height;
     if (frame_size == 0 || frame_buffer == nullptr)
     {
-        frame_size = frm->height * frm->pitch;
-        if (h->plane_count > 1)
-            frame_size += frm->heightUV * frm->pitchUV * 2;
+        frame_size = 0;
+        for (int i = 0; i < h->plane_count; i++) {
+            const int plane = h->planes[i];
+            const int rowsize = h->func.avs_get_row_size_p(frm, plane);
+            const int planeheight = h->func.avs_get_height_p(frm, plane);
+            const int target_pitch = rowsize;
+            // rowsize instead of source pitch:
+            // - pitch can be much larger than needed
+            // - can vary frame by frame, we should allocate a constant size
+            frame_size += target_pitch * planeheight;
+        }
         frame_buffer = reinterpret_cast<uint8_t*>(x265_malloc(frame_size));
     }
     pic.framesize = frame_size;
     uint8_t* ptr = frame_buffer;
-    pic.planes[0] = ptr;
-    pic.stride[0] = frm->pitch;
-    memcpy(pic.planes[0], frm->vfb->data + frm->offset, frm->pitch * frm->height);
-    if (h->plane_count > 1)
-    {
-        ptr += frm->pitch * frm->height;
-        pic.planes[1] = ptr;
-        pic.stride[1] = frm->pitchUV;
-        memcpy(pic.planes[1], frm->vfb->data + frm->offsetU, frm->pitchUV * frm->heightUV);
 
-        ptr += frm->pitchUV * frm->heightUV;
-        pic.planes[2] = ptr;
-        pic.stride[2] = frm->pitchUV;
-        memcpy(pic.planes[2], frm->vfb->data + frm->offsetV, frm->pitchUV * frm->heightUV);
+    for (int i = 0; i < h->plane_count; i++) {
+      const int plane = h->planes[i];
+      pic.planes[i] = ptr;
+
+      const uint8_t *src_p = h->func.avs_get_read_ptr_p(frm, plane);
+      int pitch = h->func.avs_get_pitch_p(frm, plane);
+      const int rowsize = h->func.avs_get_row_size_p(frm, plane);
+      const int planeheight = h->func.avs_get_height_p(frm, plane);
+
+      // Flip RGB video.
+      /* RGB not supported at the moment in x265 */
+      if (h->func.avs_is_color_space(h->vi, AVS_CS_BGR) ||
+          h->func.avs_is_color_space(h->vi, AVS_CS_BGR48) ||
+          h->func.avs_is_color_space(h->vi, AVS_CS_BGR64)) {
+          src_p = src_p + (planeheight - 1) * pitch;
+          pitch = -pitch;
+      }
+
+      const int target_pitch = rowsize; // like above
+      pic.stride[i] = target_pitch;
+
+      h->func.avs_bit_blt(h->env, ptr, target_pitch, src_p, pitch,
+          rowsize, planeheight);
+      ptr += target_pitch * planeheight;
+
     }
     pic.colorSpace = _info.csp;
     pic.bitDepth = _info.depth;

--- a/source/input/avs.h
+++ b/source/input/avs.h
@@ -32,13 +32,14 @@ namespace X265_NS {
 
 typedef struct
 {
-	AVS_Clip *clip;
-	AVS_ScriptEnvironment *env;
-	lib_t library;
-	/* declare function pointers for the utilized functions to be loaded without __declspec,
-	   as the avisynth header does not compensate for this type of usage */
-	struct
-	{
+    AVS_Clip *clip;
+    AVS_ScriptEnvironment *env;
+    const AVS_VideoInfo* vi;
+    lib_t library;
+    /* declare function pointers for the utilized functions to be loaded without __declspec,
+       as the avisynth header does not compensate for this type of usage */
+    struct
+    {
         const char *(__stdcall *avs_clip_get_error)( AVS_Clip *clip );
         AVS_ScriptEnvironment *(__stdcall *avs_create_script_environment)( int version );
         void (__stdcall *avs_delete_script_environment)( AVS_ScriptEnvironment *env );
@@ -52,14 +53,25 @@ typedef struct
         void (__stdcall *avs_release_value)( AVS_Value value );
         void (__stdcall *avs_release_video_frame)( AVS_VideoFrame *frame );
         AVS_Clip *(__stdcall *avs_take_clip)( AVS_Value, AVS_ScriptEnvironment *env );
+        void (__stdcall *avs_bit_blt)(AVS_ScriptEnvironment*, BYTE* dstp, int dst_pitch, const BYTE* srcp, int src_pitch, int row_size, int height);
+        int (__stdcall *avs_is_color_space)(const AVS_VideoInfo* p, int c_space);
         int (__stdcall *avs_is_y)(const AVS_VideoInfo * p);
         int (__stdcall *avs_is_420)(const AVS_VideoInfo * p);
         int (__stdcall *avs_is_422)(const AVS_VideoInfo * p);
         int (__stdcall *avs_is_444)(const AVS_VideoInfo * p);
+        int (__stdcall *avs_is_rgb48)(const AVS_VideoInfo* p);
+        int (__stdcall *avs_is_rgb64)(const AVS_VideoInfo* p);
+        int (__stdcall *avs_is_planar_rgb)(const AVS_VideoInfo* p);
+        int (__stdcall *avs_is_planar_rgba)(const AVS_VideoInfo* p);
         int (__stdcall *avs_bits_per_component)(const AVS_VideoInfo * p);
-	} func;
+        int (__stdcall *avs_get_pitch_p)(const AVS_VideoFrame* p, int plane);
+        int (__stdcall *avs_get_row_size_p)(const AVS_VideoFrame* p, int plane);
+        int (__stdcall *avs_get_height_p)(const AVS_VideoFrame* p, int plane);
+        const BYTE *(__stdcall *avs_get_read_ptr_p)(const AVS_VideoFrame* p, int plane);
+    } func;
     int next_frame;
     int plane_count;
+    const int* planes;
 } avs_hnd_t;
 
 class AVSInput : public InputFile
@@ -95,6 +107,12 @@ protected:
     void parseAvsOptions(const char* _options);
 
 public:
+    static const int avs_planes_packed[1];
+    static const int avs_planes_grey[1];
+    static const int avs_planes_yuv[3];
+    static const int avs_planes_rgb[3];
+    static const int avs_planes_yuva[4];
+    static const int avs_planes_rgba[4];
 
     AVSInput(InputFileInfo& info)
     {

--- a/source/input/avs.h
+++ b/source/input/avs.h
@@ -52,7 +52,7 @@ typedef struct
         void (__stdcall *avs_release_value)( AVS_Value value );
         void (__stdcall *avs_release_video_frame)( AVS_VideoFrame *frame );
         AVS_Clip *(__stdcall *avs_take_clip)( AVS_Value, AVS_ScriptEnvironment *env );
-        int (__stdcall *avs_is_y8)(const AVS_VideoInfo * p);
+        int (__stdcall *avs_is_y)(const AVS_VideoInfo * p);
         int (__stdcall *avs_is_420)(const AVS_VideoInfo * p);
         int (__stdcall *avs_is_422)(const AVS_VideoInfo * p);
         int (__stdcall *avs_is_444)(const AVS_VideoInfo * p);


### PR DESCRIPTION
Transition to C API calls instead of forbiddenly accessing internal VideoFrame fields directly.
Support more than 8-bit greyscale formats
Optimized and made deterministic the allocated buffer size.